### PR TITLE
Fix GitHub Pages deployment in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,11 +149,16 @@ jobs:
     name: Deploy page
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Set up Java (required for Android tooling)
         uses: actions/setup-java@v3
@@ -170,6 +175,15 @@ jobs:
 
       - name: Install dependencies
         run: make install
+
+      - name: Build web app
+        run: make build
         
-      - name: Deploy page
-        run: make deploy
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- The release job for deploying the Flutter web build to GitHub Pages was failing and needed to be migrated to the official Pages actions flow.
- Ensure the job has the proper permissions to publish Pages and to use the Pages deployment actions.
- Build the Flutter web artifacts in CI and upload them as the Pages artifact instead of relying on a local repo subtree deployment step.

### Description
- Updated the `deploy-page` job in `.github/workflows/release.yml` to set `permissions` to `contents: read`, `pages: write`, and `id-token: write` so Pages actions can run.
- Switched the checkout action to `actions/checkout@v4` and added `actions/configure-pages@v5` to prepare the Pages deployment environment.
- Added a CI `make build` step to produce the web output in `dist`, and replaced the manual `make deploy` subtree-based flow with `actions/upload-pages-artifact@v3` (uploading `dist`) followed by `actions/deploy-pages@v4` to publish the site.

### Testing
- No automated CI tests were executed for this change because it is a workflow-only update; behavior will be validated when the updated workflow runs on the next release event.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fa789fe88332b7be05082deb2fac)